### PR TITLE
fix: eslint `eqeqeq` warnings

### DIFF
--- a/src/TasksComponent.js
+++ b/src/TasksComponent.js
@@ -13,18 +13,18 @@ const TaskComponent = () => {
     const [errMessage, setErrorMessage] = useState(null);
 
     const addTask = (contentValue, priorityValue) => {
-        if(contentValue != "" && priorityValue != "none"){
+        if(contentValue !== "" && priorityValue !== "none"){
             let priorityNameValue;
-            if(priorityValue == 3){
+            if(priorityValue === 3){
                 priorityNameValue = "small";
             }
-            else if(priorityValue == 6){
+            else if(priorityValue === 6){
                 priorityNameValue = "normal";
             }
-            else if(priorityValue == 9){
+            else if(priorityValue === 9){
                 priorityNameValue = "medium";
             }
-            else if(priorityValue == 12){
+            else if(priorityValue === 12){
                 priorityNameValue = "high";
             }
 
@@ -71,7 +71,7 @@ const TaskComponent = () => {
     useEffect(() => {
         fetch('http://localhost:8000/tasks')
             .then(res => {
-                if(res.ok != true){
+                if(res.ok !== true){
                    throw Error("Error with featching data from this source.");
                 }
                 return res.json();


### PR DESCRIPTION
This pull request fixes ESLint `eqeqeq` compilation warnings by replacing `==` with `===` and `!==` with `!===`.

```
Compiled with warnings.

src\TasksComponent.js
  Line 16:25:  Expected '!==' and instead saw '!='  eqeqeq
  Line 16:48:  Expected '!==' and instead saw '!='  eqeqeq
  Line 18:30:  Expected '===' and instead saw '=='  eqeqeq
  Line 21:35:  Expected '===' and instead saw '=='  eqeqeq
  Line 24:35:  Expected '===' and instead saw '=='  eqeqeq
  Line 27:35:  Expected '===' and instead saw '=='  eqeqeq
  Line 74:27:  Expected '!==' and instead saw '!='  eqeqeq
```